### PR TITLE
Fixed bug when variation is 0

### DIFF
--- a/src/GoogleAnalytics/Experiment.php
+++ b/src/GoogleAnalytics/Experiment.php
@@ -375,7 +375,7 @@ class Experiment {
 	public function chooseVariation($utmx = null, $utmxx = null, $setCookies = true) {
 		$variation = $this->getChosenVariation($utmx);
 		
-		if(!$variation) {
+		if(!$variation && $variation !== 0) {
 			$variation = $this->chooseNewVariation();
 			$this->setChosenVariation($variation, $utmx, $utmxx, $setCookies);
 		}


### PR DESCRIPTION
Basically when variation is 0 it will request a new variation, thus
causing a user to possible view a new variation rather than the one
they should see.
